### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting assignment

### DIFF
--- a/marine-total-drift-vector.tsx
+++ b/marine-total-drift-vector.tsx
@@ -503,15 +503,19 @@ class MarineVectors extends React.Component<object, MarineVectorsState> {
   }
 
   updateWindData(idx: number, field: string, value: string) {
-    if (field === 'direction' || field === 'speed') {
-      this.setState(function (prevState) {
-        if (idx < prevState.windVectors.length) {
-          const wind = prevState.windVectors[idx]
-          wind[field] = parseFloat(value)
-        }
-        return { windVectors: prevState.windVectors }
-      })
+    const allowedFields = ['direction', 'speed']
+    if (!allowedFields.includes(field) || isNaN(parseFloat(value))) {
+      // Block prototype pollution attempts and any unexpected field.
+      return
     }
+    this.setState((oldState) => {
+      if (idx >= 0 && idx < oldState.windVectors.length) {
+        const updatedVectors = [...oldState.windVectors]
+        updatedVectors[idx] = { ...updatedVectors[idx], [field]: parseFloat(value) }
+        return { windVectors: updatedVectors }
+      }
+      return oldState
+    })
   }
 
   updateWindTimeFrom(idx: number, value: Date) {


### PR DESCRIPTION
Potential fix for [https://github.com/canterbury-air-patrol/marine-total-drift-vector-calculator/security/code-scanning/2](https://github.com/canterbury-air-patrol/marine-total-drift-vector-calculator/security/code-scanning/2)

The best way to fix the problem is to strictly whitelist the `field` variable, only allowing the expected keys (`'direction'` and `'speed'`) and rejecting any other value before using it as a property key. This can be done by introducing an explicit check, such as:

```typescript
if (field !== 'direction' && field !== 'speed') {
    return;
}
```

Alternatively, use a Set or array to check for allowed keys.

The change is required in the `updateWindData` function, on lines 500-510, in the file `marine-total-drift-vector.tsx`. No new imports are needed.

No other changes are required, as this single point is responsible for the prototype polluting assignment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add explicit whitelist for wind data fields to prevent prototype pollution in updateWindData