### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@canterbury-air-patrol/marine-total-drift-vector",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@canterbury-air-patrol/marine-total-drift-vector",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@canterbury-air-patrol/deg-converter": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canterbury-air-patrol/marine-total-drift-vector",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Marine Total Drift Vector Calculator",
   "main": "dist/marine-total-drift-vector.js",
   "modules": "dist/marine-total-drift-vector.mjs",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update package metadata to reflect the 0.4.2 release version.